### PR TITLE
Create batch object field cx

### DIFF
--- a/client-extensions/liferay-clarity-batch-create-distributor-object-fields/batch/00-distributor-application-object-definition.batch-engine-data.json
+++ b/client-extensions/liferay-clarity-batch-create-distributor-object-fields/batch/00-distributor-application-object-definition.batch-engine-data.json
@@ -258,17 +258,10 @@
 				"en_US": "Business License Number"
 			},
 			"name": "businessLicenseNumber",
-			"objectFieldSettings": [
-				{
-					"name": "uniqueValues",
-					"value": true
-				}
-			],
 			"readOnly": "false",
 			"required": true,
 			"state": false,
-			"type": "String",
-			"unique": true
+			"type": "String"
 		},
 		{
 			"DBType": "String",
@@ -332,17 +325,10 @@
 				"en_US": "Business Resale Number"
 			},
 			"name": "businessResaleNumber",
-			"objectFieldSettings": [
-				{
-					"name": "uniqueValues",
-					"value": true
-				}
-			],
 			"readOnly": "false",
 			"required": true,
 			"state": false,
-			"type": "String",
-			"unique": true
+			"type": "String"
 		},
 		{
 			"DBType": "String",
@@ -369,17 +355,10 @@
 				"en_US": "Business Tax ID Number"
 			},
 			"name": "businessTaxIDNumber",
-			"objectFieldSettings": [
-				{
-					"name": "uniqueValues",
-					"value": true
-				}
-			],
 			"readOnly": "false",
 			"required": true,
 			"state": false,
-			"type": "String",
-			"unique": true
+			"type": "String"
 		},
 		{
 			"DBType": "String",

--- a/client-extensions/liferay-clarity-batch-create-distributor-object-fields/batch/00-distributor-application-object-definition.batch-engine-data.json
+++ b/client-extensions/liferay-clarity-batch-create-distributor-object-fields/batch/00-distributor-application-object-definition.batch-engine-data.json
@@ -1,0 +1,535 @@
+{
+	"configuration": {
+		"className": "com.liferay.object.admin.rest.dto.v1_0.ObjectField",
+		"parameters": {
+			"containsHeaders": "true",
+			"createStrategy": "INSERT",
+			"onErrorFail": "false",
+			"updateStrategy": "UPDATE",
+			"externalReferenceCode": "D4B8_DISTRIBUTOR_APPLICATION"
+		},
+		"taskItemDelegateName": "DEFAULT"
+	},
+	"items": [
+		{
+			"DBType": "String",
+			"externalReferenceCode": "BANK_ACCOUNT_NUMBER",
+			"indexed": true,
+			"indexedAsKeyword": false,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Bank Account Number"
+			},
+			"name": "bankAccountNumber",
+			"required": false,
+			"businessType": "Text",
+			"readOnly": "false"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "BANK_ADDRESS_LINE_1",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Bank Address Line 1"
+			},
+			"name": "bankAddressLine1",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "BANK_ADDRESS_LINE_2",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Bank Address Line 2"
+			},
+			"name": "bankAddressLine2",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "BANK_CITY",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Bank City"
+			},
+			"name": "bankCity",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "BANK_COUNTRY",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Bank Country"
+			},
+			"name": "bankCountry",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "BANK_NAME",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Bank Name"
+			},
+			"name": "bankName",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "BANK_PHONE_NUMBER",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Bank Phone Number"
+			},
+			"name": "bankPhoneNumber",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "BANK_STATE_PROVINCE_REGION",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Bank State, Province, Region"
+			},
+			"name": "bankStateProvinceRegion",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "BANK_ZIP_POSTAL_CODE",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Bank ZIP, Postal Code"
+			},
+			"name": "bankZIPPostalCode",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "BUSINESS_ADDRESS_LINE_1",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Business Address Line 1"
+			},
+			"name": "businessAddressLine1",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "BUSINESS_ADDRESS_LINE_2",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Business Address Line 2"
+			},
+			"name": "businessAddressLine2",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "BUSINESS_ANNUAL_REVENUE",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Business Annual Revenue (In USD)"
+			},
+			"name": "businessAnnualRevenueInUSD",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "BUSINESS_CITY",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Business City"
+			},
+			"name": "businessCity",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "BUSINESS_COUNTRY",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Business Country"
+			},
+			"name": "businessCountry",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"type": "String"
+		},
+		{
+			"DBType": "Integer",
+			"businessType": "Integer",
+			"externalReferenceCode": "BUSINESS_EMPLOYEE_NUMBER",
+			"indexed": true,
+			"label": {
+				"en_US": "Business Employee Number"
+			},
+			"name": "businessEmployeeNumber",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"type": "Integer"
+		},
+		{
+			"DBType": "Date",
+			"businessType": "Date",
+			"externalReferenceCode": "BUSINESS_ESTABLISHED_DATE",
+			"indexed": true,
+			"label": {
+				"en_US": "Business Established Date"
+			},
+			"name": "businessEstablishedDate",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"type": "Date"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "BUSINESS_LICENSE_NUMBER",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Business License Number"
+			},
+			"name": "businessLicenseNumber",
+			"objectFieldSettings": [
+				{
+					"name": "uniqueValues",
+					"value": true
+				}
+			],
+			"readOnly": "false",
+			"required": true,
+			"state": false,
+			"type": "String",
+			"unique": true
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "BUSINESS_PHONE_NUMBER",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Business Phone Number"
+			},
+			"name": "businessPhoneNumber",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"type": "String"
+		},
+		{
+			"DBType": "Long",
+			"businessType": "Attachment",
+			"externalReferenceCode": "BUSINESS_PROOF_OF_INSURANCE",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Business Proof of Insurance"
+			},
+			"name": "businessProofOfInsurance",
+			"objectFieldSettings": [
+				{
+					"name": "acceptedFileExtensions",
+					"value": "jpeg, jpg, pdf, png"
+				},
+				{
+					"name": "fileSource",
+					"value": "userComputer"
+				},
+				{
+					"name": "maximumFileSize",
+					"value": 100
+				},
+				{
+					"name": "showFilesInDocumentsAndMedia",
+					"value": true
+				},
+				{
+					"name": "storageDLFolderPath",
+					"value": "/DistributorApplication"
+				}
+			],
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"type": "Long"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "BUSINESS_RESALE_NUMBER",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Business Resale Number"
+			},
+			"name": "businessResaleNumber",
+			"objectFieldSettings": [
+				{
+					"name": "uniqueValues",
+					"value": true
+				}
+			],
+			"readOnly": "false",
+			"required": true,
+			"state": false,
+			"type": "String",
+			"unique": true
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "BUSINESS_STATE_PROVINCE_REGION",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Business State, Province, Region"
+			},
+			"name": "businessStateProvinceRegion",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "BUSINESS_TAX_ID_NUMBER",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Business Tax ID Number"
+			},
+			"name": "businessTaxIDNumber",
+			"objectFieldSettings": [
+				{
+					"name": "uniqueValues",
+					"value": true
+				}
+			],
+			"readOnly": "false",
+			"required": true,
+			"state": false,
+			"type": "String",
+			"unique": true
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "BUSINESS_WEBSITE_URL",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Business Website URL"
+			},
+			"name": "businessWebsiteURL",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "BUSINESS_ZIP_POSTAL_CODE",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Business ZIP, Postal Code"
+			},
+			"name": "businessZIPPostalCode",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "REFERENCE_ADDRESS_LINE_1",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Reference Address Line 1"
+			},
+			"name": "referenceAddressLine1",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "REFERENCE_ADDRESS_LINE_2",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Reference Address Line 2"
+			},
+			"name": "referenceAddressLine2",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "REFERENCE_CITY",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Reference City"
+			},
+			"name": "referenceCity",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "REFERENCE_COUNTRY",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Reference Country"
+			},
+			"name": "referenceCountry",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "REFERENCE_PHONE_NUMBER",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Reference Phone Number"
+			},
+			"name": "referencePhoneNumber",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "REFERENCE_STATE_PROVINCE_REGION",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Reference State, Province, Region"
+			},
+			"name": "referenceStateProvinceRegion",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "REFERENCE_SUPPLIER_NAME",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Reference Supplier Name"
+			},
+			"name": "referenceSupplierName",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Text",
+			"externalReferenceCode": "REFERENCE_ZIP_POSTAL_CODE",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Reference ZIP, Postal Code"
+			},
+			"name": "referenceZIPPostalCode",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"type": "String"
+		}
+	]
+}

--- a/client-extensions/liferay-clarity-batch-create-distributor-object-fields/batch/01-application-evaluation-definition.batch-engine-data.json
+++ b/client-extensions/liferay-clarity-batch-create-distributor-object-fields/batch/01-application-evaluation-definition.batch-engine-data.json
@@ -1,0 +1,68 @@
+{
+	"configuration": {
+		"className": "com.liferay.object.admin.rest.dto.v1_0.ObjectField",
+		"parameters": {
+			"containsHeaders": "true",
+			"createStrategy": "INSERT",
+			"onErrorFail": "false",
+			"updateStrategy": "UPDATE",
+			"externalReferenceCode": "D4B8_APPLICATION_EVALUATION"
+		},
+		"taskItemDelegateName": "DEFAULT"
+	},
+	"items": [
+		{
+			"DBType": "Long",
+			"businessType": "Attachment",
+			"externalReferenceCode": "ATTACHMENT",
+			"indexed": true,
+			"indexedAsKeyword": false,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Attachment"
+			},
+			"name": "attachment",
+			"objectFieldSettings": [
+				{
+					"name": "acceptedFileExtensions",
+					"value": "jpeg, jpg, pdf, png"
+				},
+				{
+					"name": "fileSource",
+					"value": "userComputer"
+				},
+				{
+					"name": "maximumFileSize",
+					"value": 100
+				},
+				{
+					"name": "showFilesInDocumentsAndMedia",
+					"value": false
+				}
+			],
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"system": false,
+			"type": "Long",
+			"unique": "false"
+		},
+		{
+			"DBType": "Clob",
+			"businessType": "LongText",
+			"externalReferenceCode": "RECOMMENDATION_COMMENTS",
+			"indexed": true,
+			"indexedAsKeyword": false,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Recommendation Comments"
+			},
+			"name": "recommendationComments",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"system": false,
+			"type": "Clob"
+		}
+	]
+}

--- a/client-extensions/liferay-clarity-batch-create-distributor-object-fields/client-extension.yaml
+++ b/client-extensions/liferay-clarity-batch-create-distributor-object-fields/client-extension.yaml
@@ -3,9 +3,9 @@ assemble:
       into: batch
 liferay-clarity-batch-create-distributor-object-fields:
     name: Liferay Clarity Batch Create Distributor Object Fields
-    oAuthApplicationHeadlessServer: liferay-clarity-batch-create-distributor-object-fields-oauth-application-headless-server
+    oAuthApplicationHeadlessServer: create-distributor-object-fields-oauth-application-headless-server
     type: batch
-liferay-clarity-batch-create-distributor-object-fields-oauth-application-headless-server:
+create-distributor-object-fields-oauth-application-headless-server:
     .serviceAddress: localhost:8080
     .serviceScheme: http
     name: Liferay Clarity Batch Create Distributor Object Fields OAuth Application Headless Server

--- a/client-extensions/liferay-clarity-batch-create-distributor-object-fields/client-extension.yaml
+++ b/client-extensions/liferay-clarity-batch-create-distributor-object-fields/client-extension.yaml
@@ -1,0 +1,15 @@
+assemble:
+    - from: batch
+      into: batch
+liferay-clarity-batch-create-distributor-object-fields:
+    name: Liferay Clarity Batch Create Distributor Object Fields
+    oAuthApplicationHeadlessServer: liferay-clarity-batch-create-distributor-object-fields-oauth-application-headless-server
+    type: batch
+liferay-clarity-batch-create-distributor-object-fields-oauth-application-headless-server:
+    .serviceAddress: localhost:8080
+    .serviceScheme: http
+    name: Liferay Clarity Batch Create Distributor Object Fields OAuth Application Headless Server
+    scopes:
+        - Liferay.Headless.Batch.Engine.everything
+        - Liferay.Object.Admin.REST.everything
+    type: oAuthApplicationHeadlessServer

--- a/client-extensions/liferay-clarity-batch-create-distributor-object-picklist-fields/batch/00-distributor-application-object-definition.batch-engine-data.json
+++ b/client-extensions/liferay-clarity-batch-create-distributor-object-picklist-fields/batch/00-distributor-application-object-definition.batch-engine-data.json
@@ -1,0 +1,95 @@
+{
+	"configuration": {
+		"className": "com.liferay.object.admin.rest.dto.v1_0.ObjectField",
+		"parameters": {
+			"containsHeaders": "true",
+			"createStrategy": "INSERT",
+			"onErrorFail": "false",
+			"updateStrategy": "UPDATE",
+			"externalReferenceCode": "D4B8_DISTRIBUTOR_APPLICATION"
+		},
+		"taskItemDelegateName": "DEFAULT"
+	},
+	"items": [
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"externalReferenceCode": "ANNUAL_PURCHASE_VOLUMES",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Annual Purchase Volume"
+			},
+			"listTypeDefinitionExternalReferenceCode": "ANNUAL_PURCHASE_VOLUMES",
+			"name": "annualPurchaseVolume",
+			"readOnly": "false",
+			"required": "false",
+			"state": false,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "MultiselectPicklist",
+			"externalReferenceCode": "DISTRIBUTION_CHANNELS",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Distribution Channels"
+			},
+			"listTypeDefinitionExternalReferenceCode": "DISTRIBUTION_CHANNELS",
+			"name": "distributionChannels",
+			"readOnly": "false",
+			"required": "false",
+			"state": false,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "MultiselectPicklist",
+			"externalReferenceCode": "DISTRIBUTION_REGIONS",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Distribution Regions"
+			},
+			"listTypeDefinitionExternalReferenceCode": "DISTRIBUTION_REGIONS",
+			"name": "distributionRegions",
+			"readOnly": "false",
+			"required": "false",
+			"state": false,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "MultiselectPicklist",
+			"externalReferenceCode": "ORDER_TYPES",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Order Types of Interest"
+			},
+			"listTypeDefinitionExternalReferenceCode": "ORDER_TYPES",
+			"name": "orderTypesOfInterest",
+			"readOnly": "false",
+			"required": "false",
+			"state": false,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"externalReferenceCode": "PRODUCT_LABELS",
+			"indexed": true,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Product Label"
+			},
+			"listTypeDefinitionExternalReferenceCode": "PRODUCT_LABELS",
+			"name": "productLabel",
+			"readOnly": "false",
+			"required": "false",
+			"state": false,
+			"type": "String"
+		}
+	]
+}

--- a/client-extensions/liferay-clarity-batch-create-distributor-object-picklist-fields/batch/01-application-evaluation-definition.batch-engine-data.json
+++ b/client-extensions/liferay-clarity-batch-create-distributor-object-picklist-fields/batch/01-application-evaluation-definition.batch-engine-data.json
@@ -1,0 +1,70 @@
+{
+	"configuration": {
+		"className": "com.liferay.object.admin.rest.dto.v1_0.ObjectField",
+		"parameters": {
+			"containsHeaders": "true",
+			"createStrategy": "INSERT",
+			"onErrorFail": "false",
+			"updateStrategy": "UPDATE",
+			"externalReferenceCode": "D4B8_APPLICATION_EVALUATION"
+		},
+		"taskItemDelegateName": "DEFAULT"
+	},
+	"items": [
+		
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"externalReferenceCode": "ASSESSMENT_SCORES",
+			"indexed": true,
+			"indexedAsKeyword": false,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Assessment Score"
+			},
+			"listTypeDefinitionExternalReferenceCode": "ASSESSMENT_SCORES",
+			"name": "assessmentScore",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"system": false,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "Picklist",
+			"externalReferenceCode": "DECISIONS",
+			"indexed": true,
+			"indexedAsKeyword": false,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Decisions"
+			},
+			"listTypeDefinitionExternalReferenceCode": "DECISIONS",
+			"name": "decision",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"system": false,
+			"type": "String"
+		},
+		{
+			"DBType": "String",
+			"businessType": "MultiselectPicklist",
+			"externalReferenceCode": "RECOMMENDATIONS",
+			"indexed": true,
+			"indexedAsKeyword": false,
+			"indexedLanguageId": "en_US",
+			"label": {
+				"en_US": "Recommendations"
+			},
+			"listTypeDefinitionExternalReferenceCode": "RECOMMENDATIONS",
+			"name": "recommendations",
+			"readOnly": "false",
+			"required": false,
+			"state": false,
+			"system": false,
+			"type": "String"
+		}
+	]
+}

--- a/client-extensions/liferay-clarity-batch-create-distributor-object-picklist-fields/client-extension.yaml
+++ b/client-extensions/liferay-clarity-batch-create-distributor-object-picklist-fields/client-extension.yaml
@@ -3,9 +3,9 @@ assemble:
       into: batch
 liferay-clarity-batch-create-distributor-object-picklist-fields:
     name: Liferay Clarity Batch Create Distributor Object Picklist Fields
-    oAuthApplicationHeadlessServer: liferay-clarity-batch-create-distributor-object-picklist-fields-oauth-application-headless-server
+    oAuthApplicationHeadlessServer: create-distributor-object-picklist-fields-oauth-application-headless-server
     type: batch
-liferay-clarity-batch-create-distributor-object-picklist-fields-oauth-application-headless-server:
+create-distributor-object-picklist-fields-oauth-application-headless-server:
     .serviceAddress: localhost:8080
     .serviceScheme: http
     name: Liferay Clarity Batch Create Distributor Object Picklist Fields OAuth Application Headless Server

--- a/client-extensions/liferay-clarity-batch-create-distributor-object-picklist-fields/client-extension.yaml
+++ b/client-extensions/liferay-clarity-batch-create-distributor-object-picklist-fields/client-extension.yaml
@@ -1,0 +1,16 @@
+assemble:
+    - from: batch
+      into: batch
+liferay-clarity-batch-create-distributor-object-picklist-fields:
+    name: Liferay Clarity Batch Create Distributor Object Picklist Fields
+    oAuthApplicationHeadlessServer: liferay-clarity-batch-create-distributor-object-picklist-fields-oauth-application-headless-server
+    type: batch
+liferay-clarity-batch-create-distributor-object-picklist-fields-oauth-application-headless-server:
+    .serviceAddress: localhost:8080
+    .serviceScheme: http
+    name: Liferay Clarity Batch Create Distributor Object Picklist Fields OAuth Application Headless Server
+    scopes:
+        - Liferay.Headless.Admin.List.Type.everything
+        - Liferay.Headless.Batch.Engine.everything
+        - Liferay.Object.Admin.REST.everything
+    type: oAuthApplicationHeadlessServer

--- a/client-extensions/liferay-clarity-batch-create-picklists/client-extension.yaml
+++ b/client-extensions/liferay-clarity-batch-create-picklists/client-extension.yaml
@@ -5,7 +5,7 @@ liferay-clarity-batch-create-picklists:
     name: Liferay Clarity Batch Create Picklists
     oAuthApplicationHeadlessServer: liferay-clarity-batch-create-picklists-oauth-application-headless-server
     type: batch
-liferay-clarity-batch-create-pickists-oauth-application-headless-server:
+liferay-clarity-batch-create-picklists-oauth-application-headless-server:
     .serviceAddress: localhost:8080
     .serviceScheme: http
     name: Liferay Clarity Batch Create Picklists OAuth Application Headless Server


### PR DESCRIPTION
Creates 2 CXs to be used in lieu of two previous CXs for adding object fields. Leverages the ObjectField batch instead of ObjectDefinition batch. CXs can only be run once because update is broken for ObjectField batch.

liferay-clarity-batch-create-distributor-objects -> liferay-clarity-batch-create-distributor-object-fields
liferay-clarity-batch-update-distributor-objects -> liferay-clarity-batch-create-distributor-object-picklist-fields