### PR TITLE
Define Spring Boot JVM options for Java 17/21

### DIFF
--- a/client-extensions/liferay-clarity-etc-spring-boot/build.gradle
+++ b/client-extensions/liferay-clarity-etc-spring-boot/build.gradle
@@ -38,3 +38,14 @@ repositories {
 		url "https://repository-cdn.liferay.com/nexus/content/groups/public"
 	}
 }
+
+tasks.named("bootRun") {
+	jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
+	jvmArgs("--add-opens", "java.base/java.lang.invoke=ALL-UNNAMED")
+	jvmArgs("--add-opens", "java.base/java.lang.reflect=ALL-UNNAMED")
+	jvmArgs("--add-opens", "java.base/java.lang.net=ALL-UNNAMED")
+	jvmArgs("--add-opens", "java.base/sun.net.www.protocol.http=ALL-UNNAMED")
+	jvmArgs("--add-opens", "java.base/sun.net.www.protocol.https=ALL-UNNAMED")
+	jvmArgs("--add-opens", "java.base/sun.util.calendar=ALL-UNNAMED")
+	jvmArgs("--add-opens", "jdk.zipfs/jdk.nio.zipfs=ALL-UNNAMED")
+}


### PR DESCRIPTION
Adds JVM options for migrating Spring Boot app to Java 17/21

@dnebing, is there a better way to define JVM options in `build.gradle`?